### PR TITLE
Add gracefull native TLS support for chrome.socket

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcp-socket",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "src/tcp-socket",
   "description": "This shim brings the W3C Raw Socket API to node.js and Chromium. Its purpose is to enable apps to use the same api in Firefox OS, Chrome OS, and on the server.",
   "repository": {


### PR DESCRIPTION
Since we will probably still need forge for our socket.io proxy to provide users end-to-end TLS, I have implemented a graceful upgrade to chrome.socket.secure. This can be merged into master. From Chrome 38 upward users will automatically get the benefit of native TLS using chrome own pin-list.
