### PR TITLE
Emit the inner connection error when using chrome APIs

### DIFF
--- a/src/emailjs-tcp-socket.js
+++ b/src/emailjs-tcp-socket.js
@@ -501,7 +501,7 @@
                 chrome.socket.connect(self._socketId, self.host, self.port, function(result) {
                     if (result !== 0) {
                         self.readyState = 'closed';
-                        self._emit('error', new Error('Unable to connect'));
+                        self._emit('error', chrome.runtime.lastError);
                         return;
                     }
 
@@ -539,7 +539,7 @@
                     chrome.sockets.tcp.connect(self._socketId, self.host, self.port, function(result) {
                         if (result < 0) {
                             self.readyState = 'closed';
-                            self._emit('error', new Error('Unable to connect'));
+                            self._emit('error', chrome.runtime.lastError);
                             return;
                         }
 


### PR DESCRIPTION
Error messages are more informative, such as "DNS resolution failed".
Prevents "Unchecked runtime.lastError while running..." errors.